### PR TITLE
chore: release v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+
+## [0.0.1](https://github.com/QaidVoid/compak/compare/v0.0.0...v0.0.1) - 2025-06-29
+
+### Other
+
+- Support different zip compression algorithms - ([5498802](https://github.com/QaidVoid/compak/commit/549880224bff0cc3a81d656cc551b10430b514e0))
+- Add release workflow - ([10a46c6](https://github.com/QaidVoid/compak/commit/10a46c650e716bbe143c71cf094acedad76c3a91))
+- Re-export public interfaces to root - ([d485b53](https://github.com/QaidVoid/compak/commit/d485b53005b45a1f00c2f8f627430eacc1c9c807))
+- Add initial archive extract features - ([0aeb37a](https://github.com/QaidVoid/compak/commit/0aeb37a1eb9a7da1500f4d8f6d596e0e8da3893d))
+- Initial commit - ([d2a4a57](https://github.com/QaidVoid/compak/commit/d2a4a57f602dbf9b0cb39e3f4fcfa8ea15f7c461))
+- Initial commit - ([f10d0cb](https://github.com/QaidVoid/compak/commit/f10d0cb706e989dc4eca35bfd14ee480e33e9699))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "compak"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "bzip2 0.6.0",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compak"
 description = "A high level library for archive management"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2024"
 license = "MIT"
 authors = ["Rabindra Dhakal <contact@qaidvoid.dev>"]


### PR DESCRIPTION



## 🤖 New release

* `compak`: 0.0.0 -> 0.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.1](https://github.com/QaidVoid/compak/compare/v0.0.0...v0.0.1) - 2025-06-29

### Other

- Support different zip compression algorithms - ([5498802](https://github.com/QaidVoid/compak/commit/549880224bff0cc3a81d656cc551b10430b514e0))
- Add release workflow - ([10a46c6](https://github.com/QaidVoid/compak/commit/10a46c650e716bbe143c71cf094acedad76c3a91))
- Re-export public interfaces to root - ([d485b53](https://github.com/QaidVoid/compak/commit/d485b53005b45a1f00c2f8f627430eacc1c9c807))
- Add initial archive extract features - ([0aeb37a](https://github.com/QaidVoid/compak/commit/0aeb37a1eb9a7da1500f4d8f6d596e0e8da3893d))
- Initial commit - ([d2a4a57](https://github.com/QaidVoid/compak/commit/d2a4a57f602dbf9b0cb39e3f4fcfa8ea15f7c461))
- Initial commit - ([f10d0cb](https://github.com/QaidVoid/compak/commit/f10d0cb706e989dc4eca35bfd14ee480e33e9699))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).