### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-## [0.0.2](https://github.com/QaidVoid/compak/compare/v0.0.1...v0.0.2) - 2025-11-01
+## [0.1.0](https://github.com/QaidVoid/compak/compare/v0.0.1...v0.1.0) - 2025-11-01
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.0.2](https://github.com/QaidVoid/compak/compare/v0.0.1...v0.0.2) - 2025-11-01
+
+### Other
+
+- Add tar and 7z support, drop async and rar - ([d156b02](https://github.com/QaidVoid/compak/commit/d156b02283f7e9468c4282680fd9e7f95dd938c0))
+
 ## [0.0.1](https://github.com/QaidVoid/compak/compare/v0.0.0...v0.0.1) - 2025-06-29
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "compak"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "bzip2",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "compak"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "bzip2",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compak"
 description = "A high level library for archive management"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 license = "MIT"
 authors = ["Rabindra Dhakal <contact@qaidvoid.dev>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compak"
 description = "A high level library for archive management"
-version = "0.0.2"
+version = "0.1.0"
 edition = "2024"
 license = "MIT"
 authors = ["Rabindra Dhakal <contact@qaidvoid.dev>"]


### PR DESCRIPTION


## 🤖 New release

* `compak`: 0.0.1 -> 0.1.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/QaidVoid/compak/compare/v0.0.1...v0.1.0) - 2025-11-01

### Other

- Add tar and 7z support, drop async and rar - ([d156b02](https://github.com/QaidVoid/compak/commit/d156b02283f7e9468c4282680fd9e7f95dd938c0))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).