### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.1.1](https://github.com/QaidVoid/compak/compare/v0.1.0...v0.1.1) - 2025-12-28
+
+### Other
+
+- Update dependencies - ([f277adb](https://github.com/QaidVoid/compak/commit/f277adbc7cd2e6da706809fed3cbcd5b69990d1f))
+
 ## [0.1.0](https://github.com/QaidVoid/compak/compare/v0.0.1...v0.1.0) - 2025-11-01
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "compak"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bzip2",
  "flate2",
@@ -310,18 +310,18 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "liblzma"
-version = "0.1.10"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14557b5f35711c1193f46aa99f65a8d24432f91ca54d467a91305d1305044382"
+checksum = "73c36d08cad03a3fbe2c4e7bb3a9e84c57e4ee4135ed0b065cade3d98480c648"
 dependencies = [
  "liblzma-sys",
 ]
 
 [[package]]
 name = "liblzma-sys"
-version = "0.1.24"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52362944629858c595ba2a09bd584587bc8cca295374712cbf72d16cb58d6d"
+checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compak"
 description = "A high level library for archive management"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 authors = ["Rabindra Dhakal <contact@qaidvoid.dev>"]


### PR DESCRIPTION



## 🤖 New release

* `compak`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/QaidVoid/compak/compare/v0.1.0...v0.1.1) - 2025-12-28

### Other

- Update dependencies - ([f277adb](https://github.com/QaidVoid/compak/commit/f277adbc7cd2e6da706809fed3cbcd5b69990d1f))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).