### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.1.2](https://github.com/QaidVoid/compak/compare/v0.1.1...v0.1.2) - 2026-01-07
+
+### Other
+
+- Update supported zip compression methods - ([55a37de](https://github.com/QaidVoid/compak/commit/55a37defc8db94ebf67a85b014bd194249723a49))
+
 ## [0.1.1](https://github.com/QaidVoid/compak/compare/v0.1.0...v0.1.1) - 2025-12-28
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "compak"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bzip2",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compak"
 description = "A high level library for archive management"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "MIT"
 authors = ["Rabindra Dhakal <contact@qaidvoid.dev>"]


### PR DESCRIPTION



## 🤖 New release

* `compak`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/QaidVoid/compak/compare/v0.1.1...v0.1.2) - 2026-01-07

### Other

- Update supported zip compression methods - ([55a37de](https://github.com/QaidVoid/compak/commit/55a37defc8db94ebf67a85b014bd194249723a49))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).